### PR TITLE
Dropout layers are turned off  when crafting samples (issue #1)

### DIFF
--- a/scripts/craft_adv_samples.py
+++ b/scripts/craft_adv_samples.py
@@ -83,6 +83,7 @@ def main(args):
     # Create TF session, set it as Keras backend
     sess = tf.Session()
     K.set_session(sess)
+    K.set_learning_phase(0)
     model = load_model('../data/model_%s.h5' % args.dataset)
     _, _, X_test, Y_test = get_data(args.dataset)
     _, acc = model.evaluate(X_test, Y_test, batch_size=args.batch_size,


### PR DESCRIPTION
Found a way simpler way to address the issue of Dropout still being "on" during the feed-forward.
As far as I can tell, this is the only place that is needed.